### PR TITLE
Conditional operator replaced with short circuit Evaluation

### DIFF
--- a/src/scripts/views/mainView.js
+++ b/src/scripts/views/mainView.js
@@ -10,8 +10,7 @@ export default class MainView
 
     toggleAddTaskFormVisibility(visible, id)
     {
-        const displayValue = visible ? 'block' : 'none';
-        this.getByID(id).style.display = displayValue;
+        this.getByID(id).style.display = visible && 'block' || 'none';
     }
     getAddTaskFormElementValueByName(elementName)
     {


### PR DESCRIPTION
By only evaluating the second operand when it is safe, short-circuiting can prevent errors.
[Reference from StackOverflow](https://stackoverflow.com/questions/40413519/difference-between-using-a-ternary-operator-or-just-short-circuit-evaluation)